### PR TITLE
Sample type checking

### DIFF
--- a/src/adherer_core.rs
+++ b/src/adherer_core.rs
@@ -2,16 +2,7 @@ use core::fmt;
 
 use nalgebra::SVector;
 
-use crate::structs::{Classifier, Halfspace, Sample};
-
-/// An error that occurred from sampling an system under test's input space.
-#[derive(Clone, PartialEq)]
-pub enum SamplingError<const N: usize> {
-    BoundaryLost,
-    OutOfBounds,
-    MaxSamplesExceeded,
-    InvalidClassifierResponse(String),
-}
+use crate::structs::{Classifier, Halfspace, Sample, SamplingError};
 
 /// A valid state of an adherer.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/adherers/const_adherer.rs
+++ b/src/adherers/const_adherer.rs
@@ -54,7 +54,7 @@ impl<const N: usize> ConstantAdherer<N> {
         &mut self,
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
-        let cur = self.pivot.b + self.v;
+        let cur = *self.pivot.b + self.v;
         let cls = classifier.classify(cur)?;
         let delta_angle = if cls {
             self.delta_angle
@@ -62,7 +62,7 @@ impl<const N: usize> ConstantAdherer<N> {
             -self.delta_angle
         };
         self.rot = Some(self.span.get_rotater()(delta_angle));
-        Ok(Sample::new(cur, cls))
+        Ok(Sample::from_class(cur, cls))
     }
 
     fn take_sample(
@@ -71,12 +71,12 @@ impl<const N: usize> ConstantAdherer<N> {
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
         self.v = rot * self.v;
-        let cur = self.pivot.b + self.v;
+        let cur = *self.pivot.b + self.v;
         let cls = classifier.classify(cur)?;
 
         self.angle += self.delta_angle;
 
-        Ok(Sample::new(cur, cls))
+        Ok(Sample::from_class(cur, cls))
     }
 }
 
@@ -101,7 +101,7 @@ impl<const N: usize> Adherer<N> for ConstantAdherer<N> {
                 (Sample::WithinMode(t), Sample::OutOfMode(_))
                 | (Sample::OutOfMode(_), Sample::WithinMode(t)) => {
                     let b = *t;
-                    let s = b - self.pivot.b;
+                    let s = *b - *self.pivot.b;
                     let rot90 = self.span.get_rotater()(PI / 2.0);
                     let n = (rot90 * s).normalize();
                     self.state = AdhererState::FoundBoundary(Halfspace { b, n });

--- a/src/adherers/const_adherer.rs
+++ b/src/adherers/const_adherer.rs
@@ -1,6 +1,6 @@
 use crate::{
-    adherer_core::{Adherer, AdhererFactory, AdhererState, SamplingError},
-    structs::{Classifier, Halfspace, Sample, Span},
+    adherer_core::{Adherer, AdhererFactory, AdhererState},
+    structs::{Classifier, Halfspace, Sample, SamplingError, Span},
 };
 use nalgebra::{Const, OMatrix, SVector};
 use std::f64::consts::PI;

--- a/src/adherers/const_adherer.rs
+++ b/src/adherers/const_adherer.rs
@@ -55,7 +55,7 @@ impl<const N: usize> ConstantAdherer<N> {
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
         let cur = *self.pivot.b + self.v;
-        let cls = classifier.classify(cur)?;
+        let cls = classifier.classify(&cur)?;
         let delta_angle = if cls {
             self.delta_angle
         } else {
@@ -72,7 +72,7 @@ impl<const N: usize> ConstantAdherer<N> {
     ) -> Result<Sample<N>, SamplingError<N>> {
         self.v = rot * self.v;
         let cur = *self.pivot.b + self.v;
-        let cls = classifier.classify(cur)?;
+        let cls = classifier.classify(&cur)?;
 
         self.angle += self.delta_angle;
 

--- a/src/adherers/const_adherer.rs
+++ b/src/adherers/const_adherer.rs
@@ -54,7 +54,7 @@ impl<const N: usize> ConstantAdherer<N> {
         &mut self,
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
-        let cur = *self.pivot.b + self.v;
+        let cur = self.pivot.b + self.v;
         let cls = classifier.classify(&cur)?;
         let delta_angle = if cls {
             self.delta_angle
@@ -71,7 +71,7 @@ impl<const N: usize> ConstantAdherer<N> {
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
         self.v = rot * self.v;
-        let cur = *self.pivot.b + self.v;
+        let cur = self.pivot.b + self.v;
         let cls = classifier.classify(&cur)?;
 
         self.angle += self.delta_angle;
@@ -101,7 +101,7 @@ impl<const N: usize> Adherer<N> for ConstantAdherer<N> {
                 (Sample::WithinMode(t), Sample::OutOfMode(_))
                 | (Sample::OutOfMode(_), Sample::WithinMode(t)) => {
                     let b = *t;
-                    let s = *b - *self.pivot.b;
+                    let s = b - self.pivot.b;
                     let rot90 = self.span.get_rotater()(PI / 2.0);
                     let n = (rot90 * s).normalize();
                     self.state = AdhererState::FoundBoundary(Halfspace { b, n });

--- a/src/api.rs
+++ b/src/api.rs
@@ -97,12 +97,12 @@ impl<const N: usize> From<io::Error> for SamplingError<N> {
 
 impl<const N: usize> Classifier<N> for RemoteClassifier<N> {
     fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
-        if !self.domain.contains(&p) {
+        if !self.domain.contains(p) {
             return Err(SamplingError::OutOfBounds);
         }
 
         // Send request
-        let v: Vec<f64> = svector_to_array(p.clone()).to_vec();
+        let v: Vec<f64> = svector_to_array(*p).to_vec();
         let r = ClassifierRequest { p: v };
         let json = serde_json::to_string(&r).expect("Invalid ClassifierRequest serialization?");
         self.stream

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,10 +1,10 @@
+use crate::structs::SamplingError;
 use nalgebra::SVector;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::io::{self, Read};
 use std::net;
 
-use crate::adherer_core::SamplingError;
 use crate::structs::Domain;
 use crate::{structs::Classifier, utils::svector_to_array};
 
@@ -96,10 +96,7 @@ impl<const N: usize> From<io::Error> for SamplingError<N> {
 }
 
 impl<const N: usize> Classifier<N> for RemoteClassifier<N> {
-    fn classify(
-        &mut self,
-        p: SVector<f64, N>,
-    ) -> Result<bool, crate::adherer_core::SamplingError<N>> {
+    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
         if !self.domain.contains(&p) {
             return Err(SamplingError::OutOfBounds);
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -96,13 +96,13 @@ impl<const N: usize> From<io::Error> for SamplingError<N> {
 }
 
 impl<const N: usize> Classifier<N> for RemoteClassifier<N> {
-    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+    fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
         if !self.domain.contains(&p) {
             return Err(SamplingError::OutOfBounds);
         }
 
         // Send request
-        let v: Vec<f64> = svector_to_array(p).to_vec();
+        let v: Vec<f64> = svector_to_array(p.clone()).to_vec();
         let r = ClassifierRequest { p: v };
         let json = serde_json::to_string(&r).expect("Invalid ClassifierRequest serialization?");
         self.stream

--- a/src/explorer_core.rs
+++ b/src/explorer_core.rs
@@ -1,6 +1,7 @@
 use crate::{
     adherer_core::SamplingError,
     structs::{Classifier, Halfspace, Sample},
+    // structs::{Classifier, Halfspace, Sample},
 };
 
 /// The system responsible for the full boundary exploration process. Leverages

--- a/src/explorer_core.rs
+++ b/src/explorer_core.rs
@@ -1,6 +1,5 @@
 use crate::{
-    adherer_core::SamplingError,
-    structs::{Classifier, Halfspace, Sample},
+    structs::{Classifier, Halfspace, Sample, SamplingError},
     // structs::{Classifier, Halfspace, Sample},
 };
 

--- a/src/explorers/mesh_explorer.rs
+++ b/src/explorers/mesh_explorer.rs
@@ -1,8 +1,8 @@
 use crate::{
-    adherer_core::{Adherer, AdhererFactory, AdhererState, SamplingError},
+    adherer_core::{Adherer, AdhererFactory, AdhererState},
     explorer_core::Explorer,
     extensions::Queue,
-    structs::{Classifier, Halfspace, Sample, Span},
+    structs::{Classifier, Halfspace, Sample, SamplingError, Span},
     utils::{array_distance, svector_to_array},
 };
 use nalgebra::{self, Const, OMatrix, SVector};

--- a/src/explorers/mesh_explorer.rs
+++ b/src/explorers/mesh_explorer.rs
@@ -94,7 +94,7 @@ impl<const N: usize> MeshExplorer<N> {
         self.path_queue
             .extend(self.get_next_paths_from(next_id.index()));
 
-        let b = svector_to_array(*hs.b);
+        let b: [f64; N] = hs.b.into();
 
         self.knn_index.insert(KnnNode::new(b, next_id.index()));
     }

--- a/src/explorers/mesh_explorer.rs
+++ b/src/explorers/mesh_explorer.rs
@@ -75,7 +75,7 @@ impl<const N: usize> MeshExplorer<N> {
     fn select_parent(&mut self) -> Option<(Halfspace<N>, NodeID, SVector<f64, N>)> {
         while let Some((id, v)) = self.path_queue.dequeue() {
             let hs = &self.boundary[id];
-            let p = hs.b + self.d * v;
+            let p = *hs.b + self.d * v;
 
             if !self.check_overlap(p) {
                 return Some((*hs, id, v));
@@ -94,7 +94,7 @@ impl<const N: usize> MeshExplorer<N> {
         self.path_queue
             .extend(self.get_next_paths_from(next_id.index()));
 
-        let b = svector_to_array(hs.b);
+        let b = svector_to_array(*hs.b);
 
         self.knn_index.insert(KnnNode::new(b, next_id.index()));
     }

--- a/src/explorers/mesh_explorer.rs
+++ b/src/explorers/mesh_explorer.rs
@@ -163,7 +163,7 @@ impl<const N: usize> Explorer<N> for MeshExplorer<N> {
 
             // Clone needed, lifespan of sample attached to adherer. Adherer will be
             // dropped when boundary found.
-            let sample = sample.clone();
+            let sample = *sample;
             let state = adh.get_state();
 
             if let AdhererState::FoundBoundary(hs) = state {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,3 +1,10 @@
+use nalgebra::SVector;
+
+use crate::{
+    structs::{OutOfMode, Sample, WithinMode},
+    utils::svector_to_array,
+};
+
 pub trait Queue<T> {
     fn enqueue(&mut self, x: T);
     fn dequeue(&mut self) -> Option<T>;
@@ -14,5 +21,35 @@ impl<T> Queue<T> for Vec<T> {
         } else {
             Some(self.remove(0))
         }
+    }
+}
+
+impl<const N: usize> From<Sample<N>> for SVector<f64, N> {
+    fn from(value: Sample<N>) -> Self {
+        value.into_inner()
+    }
+}
+
+impl<const N: usize> From<WithinMode<N>> for SVector<f64, N> {
+    fn from(value: WithinMode<N>) -> Self {
+        value.0
+    }
+}
+
+impl<const N: usize> From<WithinMode<N>> for [f64; N] {
+    fn from(value: WithinMode<N>) -> Self {
+        svector_to_array(value.0)
+    }
+}
+
+impl<const N: usize> From<OutOfMode<N>> for SVector<f64, N> {
+    fn from(value: OutOfMode<N>) -> Self {
+        value.0
+    }
+}
+
+impl<const N: usize> From<OutOfMode<N>> for [f64; N] {
+    fn from(value: OutOfMode<N>) -> Self {
+        svector_to_array(value.0)
     }
 }

--- a/src/search/global_search.rs
+++ b/src/search/global_search.rs
@@ -22,7 +22,7 @@ impl<const N: usize> MonteCarloSearch<N> {
 
 impl<const N: usize> SearchFactory<N> for MonteCarloSearch<N> {
     fn sample(&mut self) -> SVector<f64, N> {
-        let mut v: SVector<f64, N> = SVector::from_fn(|_, _| self.rng.gen());
+        let v: SVector<f64, N> = SVector::from_fn(|_, _| self.rng.gen());
         v.component_mul(&self.domain.dimensions()) + self.domain.low()
     }
 

--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -1,7 +1,7 @@
 use nalgebra::SVector;
 
 use crate::{
-    adherer_core::SamplingError,
+    structs::SamplingError,
     structs::{BoundaryPair, Classifier, Halfspace, WithinMode},
 };
 
@@ -51,9 +51,8 @@ pub fn binary_surface_search<const N: usize>(
 mod test_surfacer {
     use nalgebra::SVector;
 
-    use crate::{
-        adherer_core::SamplingError,
-        structs::{BoundaryPair, Classifier, Domain, OutOfMode, Sample, WithinMode},
+    use crate::structs::{
+        BoundaryPair, Classifier, Domain, OutOfMode, Sample, SamplingError, WithinMode,
     };
 
     use super::binary_surface_search;

--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -1,5 +1,3 @@
-use nalgebra::SVector;
-
 use crate::{
     structs::SamplingError,
     structs::{BoundaryPair, Classifier, Halfspace, WithinMode},
@@ -51,9 +49,7 @@ pub fn binary_surface_search<const N: usize>(
 mod test_surfacer {
     use nalgebra::SVector;
 
-    use crate::structs::{
-        BoundaryPair, Classifier, Domain, OutOfMode, Sample, SamplingError, WithinMode,
-    };
+    use crate::structs::{BoundaryPair, Classifier, Domain, OutOfMode, SamplingError, WithinMode};
 
     use super::binary_surface_search;
 
@@ -68,7 +64,7 @@ mod test_surfacer {
 
     impl<const N: usize> Classifier<N> for Sphere<N> {
         fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
-            if !self.domain.contains(&p) {
+            if !self.domain.contains(p) {
                 return Err(SamplingError::OutOfBounds);
             }
 

--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -19,13 +19,13 @@ pub fn binary_surface_search<const N: usize>(
     max_samples: u32,
     classifier: &mut Box<dyn Classifier<N>>,
 ) -> Result<Halfspace<N>, SamplingError<N>> {
-    let mut p_t = **b_pair.t();
-    let mut p_x = **b_pair.x();
+    let mut p_t = b_pair.t().0;
+    let mut p_x = b_pair.x().0;
     let mut s = (p_x - p_t) / 2.0;
     let mut i = 0;
 
     while s.norm() > d && i < max_samples {
-        if classifier.classify(p_t + s)? {
+        if classifier.classify(&(p_t + s))? {
             p_t += s;
         } else {
             p_x -= s;
@@ -67,7 +67,7 @@ mod test_surfacer {
     }
 
     impl<const N: usize> Classifier<N> for Sphere<N> {
-        fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+        fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
             if !self.domain.contains(&p) {
                 return Err(SamplingError::OutOfBounds);
             }
@@ -106,11 +106,11 @@ mod test_surfacer {
             .expect("Failed to find boundary?");
 
         assert!(
-            sphere.classify(*hs.b).unwrap(),
+            sphere.classify(&hs.b).unwrap(),
             "Halfspace outside of geometry?"
         );
         assert!(
-            !sphere.classify(*hs.b + hs.n * d).unwrap(),
+            !sphere.classify(&(hs.b + hs.n * d)).unwrap(),
             "Halfspace not on boundary?"
         );
     }
@@ -134,11 +134,11 @@ mod test_surfacer {
             .expect("Failed to find boundary within the maximum number of samples ({max_samples})");
 
         assert!(
-            sphere.classify(*hs.b).unwrap(),
+            sphere.classify(&hs.b).unwrap(),
             "Halfspace outside of geometry?"
         );
         assert!(
-            !sphere.classify(*hs.b + hs.n * d).unwrap(),
+            !sphere.classify(&(hs.b + hs.n * d)).unwrap(),
             "Halfspace not on boundary?"
         );
     }

--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -1,6 +1,8 @@
+use nalgebra::SVector;
+
 use crate::{
     adherer_core::SamplingError,
-    structs::{BoundaryPair, Classifier, Halfspace},
+    structs::{BoundaryPair, Classifier, Halfspace, WithinMode},
 };
 
 /// Finds the surface of an envelope, i.e. the initial halfspace for beginning
@@ -17,8 +19,8 @@ pub fn binary_surface_search<const N: usize>(
     max_samples: u32,
     classifier: &mut Box<dyn Classifier<N>>,
 ) -> Result<Halfspace<N>, SamplingError<N>> {
-    let mut p_t = b_pair.t().into_inner();
-    let mut p_x = b_pair.x().into_inner();
+    let mut p_t = **b_pair.t();
+    let mut p_x = **b_pair.x();
     let mut s = (p_x - p_t) / 2.0;
     let mut i = 0;
 
@@ -39,7 +41,10 @@ pub fn binary_surface_search<const N: usize>(
 
     let n = s.normalize();
 
-    Ok(Halfspace { b: p_t, n })
+    Ok(Halfspace {
+        b: WithinMode(p_t),
+        n,
+    })
 }
 
 #[cfg(test)]
@@ -48,7 +53,7 @@ mod test_surfacer {
 
     use crate::{
         adherer_core::SamplingError,
-        structs::{BoundaryPair, Classifier, Domain, Sample},
+        structs::{BoundaryPair, Classifier, Domain, OutOfMode, Sample, WithinMode},
     };
 
     use super::binary_surface_search;
@@ -93,20 +98,20 @@ mod test_surfacer {
         // a little perturbed from the center
         let mut t = SVector::from_fn(|_, _| 0.5);
         t[D - 1] += 0.15;
-        let t = Sample::new(t, sphere.classify(t).unwrap());
+        let t = WithinMode(t);
         let mut x = SVector::from_fn(|_, _| 0.15);
         x[0] += 0.3;
-        let x = Sample::new(x, sphere.classify(x).unwrap());
+        let x = OutOfMode(x);
 
         let hs = binary_surface_search(d, &BoundaryPair::new(t, x), 100, &mut sphere)
             .expect("Failed to find boundary?");
 
         assert!(
-            sphere.classify(hs.b).unwrap(),
+            sphere.classify(*hs.b).unwrap(),
             "Halfspace outside of geometry?"
         );
         assert!(
-            !sphere.classify(hs.b + hs.n * d).unwrap(),
+            !sphere.classify(*hs.b + hs.n * d).unwrap(),
             "Halfspace not on boundary?"
         );
     }
@@ -120,22 +125,21 @@ mod test_surfacer {
         // a little perturbed from the center
         let mut t = SVector::from_fn(|_, _| 0.5);
         t[D - 1] += 0.15;
-        let t = Sample::new(t, sphere.classify(t).unwrap());
+        let t = WithinMode(t);
         let mut x = SVector::from_fn(|_, _| 0.15);
         x[0] += 0.3;
-        let x = Sample::new(x, sphere.classify(x).unwrap());
-
+        let x = OutOfMode(x);
         let max_samples = (DIAMETER / d).log2().ceil() as u32;
 
         let hs = binary_surface_search(d, &BoundaryPair::new(t, x), max_samples, &mut sphere)
             .expect("Failed to find boundary within the maximum number of samples ({max_samples})");
 
         assert!(
-            sphere.classify(hs.b).unwrap(),
+            sphere.classify(*hs.b).unwrap(),
             "Halfspace outside of geometry?"
         );
         assert!(
-            !sphere.classify(hs.b + hs.n * d).unwrap(),
+            !sphere.classify(*hs.b + hs.n * d).unwrap(),
             "Halfspace not on boundary?"
         );
     }
@@ -148,11 +152,11 @@ mod test_surfacer {
 
         // a little perturbed from the center
         let t = SVector::from_fn(|_, _| 0.5);
-        let t = Sample::new(t, sphere.classify(t).unwrap());
+        let t = WithinMode(t);
+
         let mut x = SVector::from_fn(|_, _| 0.5);
         x[0] = 0.0;
-        let x = Sample::new(x, sphere.classify(x).unwrap());
-
+        let x = OutOfMode(x);
         let minimum_sample_count = (RADIUS / d).log2().ceil() as u32;
 
         let err: SamplingError<10> = binary_surface_search(

--- a/src/structs/boundary.rs
+++ b/src/structs/boundary.rs
@@ -1,0 +1,32 @@
+use nalgebra::SVector;
+
+use super::{OutOfMode, WithinMode};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoundaryPair<const N: usize> {
+    t: WithinMode<N>,
+    x: OutOfMode<N>,
+}
+
+/// A halfspace is the smallest discrete unit of a hyper-geometry's surface. It
+/// describes the location (the boundary point, b) and the direction of the surface
+/// (the ortho[n]ormal surface vector, n).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Halfspace<const N: usize> {
+    pub b: WithinMode<N>,
+    pub n: SVector<f64, N>,
+}
+
+impl<const N: usize> BoundaryPair<N> {
+    pub fn new(t: WithinMode<N>, x: OutOfMode<N>) -> Self {
+        BoundaryPair { t, x }
+    }
+
+    pub fn t(&self) -> &WithinMode<N> {
+        &self.t
+    }
+
+    pub fn x(&self) -> &OutOfMode<N> {
+        &self.x
+    }
+}

--- a/src/structs/error.rs
+++ b/src/structs/error.rs
@@ -1,0 +1,8 @@
+/// An error that occurred from sampling an system under test's input space.
+#[derive(Clone, PartialEq)]
+pub enum SamplingError<const N: usize> {
+    BoundaryLost,
+    OutOfBounds,
+    MaxSamplesExceeded,
+    InvalidClassifierResponse(String),
+}

--- a/src/structs/sampling.rs
+++ b/src/structs/sampling.rs
@@ -7,7 +7,7 @@ use crate::structs::SamplingError;
 /// A system under test whose output can be classified as "target" or "non-target"
 /// behavior. For example, safe/unsafe.
 pub trait Classifier<const N: usize> {
-    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>>;
+    fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>>;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/structs/sampling.rs
+++ b/src/structs/sampling.rs
@@ -2,7 +2,7 @@ use std::{fmt, ops::Deref};
 
 use nalgebra::SVector;
 
-use crate::adherer_core::SamplingError;
+use crate::structs::SamplingError;
 
 /// A system under test whose output can be classified as "target" or "non-target"
 /// behavior. For example, safe/unsafe.

--- a/src/structs/sampling.rs
+++ b/src/structs/sampling.rs
@@ -1,4 +1,7 @@
-use std::{fmt, ops::Deref};
+use std::{
+    fmt,
+    ops::{Add, Deref, Sub},
+};
 
 use nalgebra::SVector;
 
@@ -40,6 +43,15 @@ impl<const N: usize> Sample<N> {
     }
 }
 
+impl<const N: usize> fmt::Display for Sample<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Sample::WithinMode(t) => write!(f, "Target(p: {:?})", t),
+            Sample::OutOfMode(x) => write!(f, "Non-Target(p: {:?})", x),
+        }
+    }
+}
+
 impl<const N: usize> Deref for Sample<N> {
     type Target = SVector<f64, N>;
 
@@ -58,6 +70,7 @@ impl<const N: usize> Deref for WithinMode<N> {
         &self.0
     }
 }
+
 impl<const N: usize> Deref for OutOfMode<N> {
     type Target = SVector<f64, N>;
 
@@ -66,11 +79,48 @@ impl<const N: usize> Deref for OutOfMode<N> {
     }
 }
 
-impl<const N: usize> fmt::Display for Sample<N> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            Sample::WithinMode(t) => write!(f, "Target(p: {:?})", t),
-            Sample::OutOfMode(x) => write!(f, "Non-Target(p: {:?})", x),
-        }
+// Operators for samples
+
+impl<const N: usize> Add for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        self.0 + rhs.0
+    }
+}
+impl<const N: usize> Add<OutOfMode<N>> for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn add(self, rhs: OutOfMode<N>) -> Self::Output {
+        self.0 + rhs.0
+    }
+}
+impl<const N: usize> Add<SVector<f64, N>> for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn add(self, rhs: SVector<f64, N>) -> Self::Output {
+        self.0 + rhs
+    }
+}
+
+impl<const N: usize> Sub for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+impl<const N: usize> Sub<OutOfMode<N>> for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn sub(self, rhs: OutOfMode<N>) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+impl<const N: usize> Sub<SVector<f64, N>> for WithinMode<N> {
+    type Output = SVector<f64, N>;
+
+    fn sub(self, rhs: SVector<f64, N>) -> Self::Output {
+        self.0 - rhs
     }
 }

--- a/src/structs/sampling.rs
+++ b/src/structs/sampling.rs
@@ -1,0 +1,76 @@
+use std::{fmt, ops::Deref};
+
+use nalgebra::SVector;
+
+use crate::adherer_core::SamplingError;
+
+/// A system under test whose output can be classified as "target" or "non-target"
+/// behavior. For example, safe/unsafe.
+pub trait Classifier<const N: usize> {
+    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WithinMode<const N: usize>(pub SVector<f64, N>);
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OutOfMode<const N: usize>(pub SVector<f64, N>);
+
+/// A sample from the system under test's input space with a corresponding target
+/// performance classification.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Sample<const N: usize> {
+    WithinMode(WithinMode<N>),
+    OutOfMode(OutOfMode<N>),
+}
+
+impl<const N: usize> Sample<N> {
+    pub fn from_class(p: SVector<f64, N>, cls: bool) -> Self {
+        if cls {
+            Sample::WithinMode(WithinMode(p))
+        } else {
+            Sample::OutOfMode(OutOfMode(p))
+        }
+    }
+
+    pub fn into_inner(self) -> SVector<f64, N> {
+        match self {
+            Sample::WithinMode(WithinMode(p)) => p,
+            Sample::OutOfMode(OutOfMode(p)) => p,
+        }
+    }
+}
+
+impl<const N: usize> Deref for Sample<N> {
+    type Target = SVector<f64, N>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Sample::WithinMode(WithinMode(t)) => t,
+            Sample::OutOfMode(OutOfMode(x)) => x,
+        }
+    }
+}
+
+impl<const N: usize> Deref for WithinMode<N> {
+    type Target = SVector<f64, N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl<const N: usize> Deref for OutOfMode<N> {
+    type Target = SVector<f64, N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const N: usize> fmt::Display for Sample<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Sample::WithinMode(t) => write!(f, "Target(p: {:?})", t),
+            Sample::OutOfMode(x) => write!(f, "Non-Target(p: {:?})", x),
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,19 +2,9 @@ use nalgebra::SVector;
 use std::fmt::Write;
 
 pub fn svector_to_array<const N: usize>(v: SVector<f64, N>) -> [f64; N] {
-    // let mut arr = [0.0; N];
-    // for i in 0..N {
-    //     arr[i] = v[i];
-    // }
-    // return arr;
-
-    let arr;
-    unsafe {
-        let ptr = v.as_ptr();
-        arr = std::slice::from_raw_parts(ptr, N).try_into().unwrap();
-    }
-
-    arr
+    v.as_slice()
+        .try_into()
+        .expect("Failed to convert slice to array.")
 }
 
 pub fn array_distance<const N: usize>(a1: &[f64; N], a2: &[f64; N]) -> f64 {
@@ -44,4 +34,40 @@ pub fn vector_to_string<const N: usize>(v: &SVector<f64, N>) -> String {
 
     write!(result, "]").unwrap();
     result
+}
+
+#[cfg(test)]
+mod test {
+    use nalgebra::{vector, SVector};
+
+    use super::svector_to_array;
+
+    #[test]
+    fn convert_nonempty_svector_to_array() {
+        let v = SVector::<f64, 20>::from_fn(|_, _| 0.5);
+        let arr = svector_to_array(v);
+
+        assert!(
+            v.iter().zip(arr.iter()).all(|(a, b)| a == b),
+            "Not all elements are equal?"
+        )
+    }
+
+    #[test]
+    fn convert_single_element_svector_to_array() {
+        let v = vector![0.5];
+        let arr = svector_to_array(v);
+
+        assert!(
+            v.iter().zip(arr.iter()).all(|(a, b)| a == b),
+            "Not all elements are equal?"
+        )
+    }
+
+    #[test]
+    fn convert_empty_svector_to_array() {
+        let v = vector![];
+        let arr = svector_to_array(v);
+        assert!(arr.len() == 0, "Not zero?");
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,6 +68,6 @@ mod test {
     fn convert_empty_svector_to_array() {
         let v = vector![];
         let arr = svector_to_array(v);
-        assert!(arr.len() == 0, "Not zero?");
+        assert!(arr.is_empty(), "Not zero?");
     }
 }

--- a/tests/adherence.rs
+++ b/tests/adherence.rs
@@ -2,9 +2,9 @@ use core::panic;
 
 use nalgebra::{vector, SVector};
 use sembas::{
-    adherer_core::{Adherer, AdhererState, SamplingError},
+    adherer_core::{Adherer, AdhererState},
     adherers,
-    structs::{Classifier, Domain, Halfspace, WithinMode},
+    structs::{Classifier, Domain, Halfspace, SamplingError, WithinMode},
 };
 
 struct Cube<const N: usize> {
@@ -22,10 +22,7 @@ impl<const N: usize> Cube<N> {
 }
 
 impl<const N: usize> Classifier<N> for Cube<N> {
-    fn classify(
-        &mut self,
-        p: SVector<f64, N>,
-    ) -> Result<bool, sembas::adherer_core::SamplingError<N>> {
+    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
         if !self.domain.contains(&p) {
             return Err(SamplingError::OutOfBounds);
         }

--- a/tests/adherence.rs
+++ b/tests/adherence.rs
@@ -22,12 +22,12 @@ impl<const N: usize> Cube<N> {
 }
 
 impl<const N: usize> Classifier<N> for Cube<N> {
-    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
-        if !self.domain.contains(&p) {
+    fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+        if !self.domain.contains(p) {
             return Err(SamplingError::OutOfBounds);
         }
 
-        Ok(self.shape.contains(&p))
+        Ok(self.shape.contains(p))
     }
 }
 

--- a/tests/adherence.rs
+++ b/tests/adherence.rs
@@ -4,7 +4,7 @@ use nalgebra::{vector, SVector};
 use sembas::{
     adherer_core::{Adherer, AdhererState, SamplingError},
     adherers,
-    structs::{Classifier, Domain, Halfspace},
+    structs::{Classifier, Domain, Halfspace, WithinMode},
 };
 
 struct Cube<const N: usize> {
@@ -38,7 +38,7 @@ impl<const N: usize> Classifier<N> for Cube<N> {
 fn finds_boundary_when_near() {
     let dist = 0.1;
 
-    let b = vector![0.5, 0.5, 0.71];
+    let b = WithinMode(vector![0.5, 0.5, 0.71]);
     let n = vector![0.0, 0.0, 1.0];
     let pivot = Halfspace { b, n };
     let v = dist * vector![1.0, 0.0, 0.0];
@@ -47,7 +47,7 @@ fn finds_boundary_when_near() {
 
     let cube = Cube::new(0.25, vector![0.5, 0.5, 0.5], Domain::normalized());
 
-    let z_dist = (b - cube.shape.high())[2];
+    let z_dist = (*b - cube.shape.high())[2];
     let angle_to_boundary = (z_dist / dist).asin();
     let n_steps_to_boundary = (angle_to_boundary / delta_angle).ceil() as i32;
 
@@ -71,7 +71,7 @@ fn finds_boundary_when_near() {
 fn loses_boundary_when_out_of_reach() {
     let dist = 0.1;
 
-    let b = vector![0.5, 0.5, 0.5];
+    let b = WithinMode(vector![0.5, 0.5, 0.5]);
     let n = vector![0.0, 0.0, 1.0];
     let pivot = Halfspace { b, n };
     let v = dist * vector![1.0, 0.0, 0.0];

--- a/tests/exploration.rs
+++ b/tests/exploration.rs
@@ -6,7 +6,7 @@ use sembas::{
     adherers::const_adherer::ConstantAdhererFactory,
     explorer_core::Explorer,
     explorers::MeshExplorer,
-    structs::{Classifier, Domain, Halfspace},
+    structs::{Classifier, Domain, Halfspace, WithinMode},
 };
 
 const D: usize = 10;
@@ -36,7 +36,13 @@ impl<const N: usize> Classifier<N> for Sphere<N> {
 }
 
 fn setup_mesh_expl<const N: usize>(sphere: &Sphere<N>) -> MeshExplorer<N> {
-    let b = SVector::from_fn(|i, _| if i == 0 { 0.49 + sphere.radius } else { 0.5 });
+    let b = WithinMode(SVector::from_fn(|i, _| {
+        if i == 0 {
+            0.49 + sphere.radius
+        } else {
+            0.5
+        }
+    }));
     let mut n = SVector::zeros();
     n[0] = 1.0;
     let root = Halfspace { b, n };
@@ -115,7 +121,7 @@ fn fully_explores_sphere() {
     // In order to know that we explored the sphere, we need to know it covered the
     // full shape. To do this, we can find the average position and make sure it was
     // close to the center.
-    let boundary_points = expl.boundary().iter().map(|x| x.b).collect();
+    let boundary_points = expl.boundary().iter().map(|x| *x.b).collect();
     let center_of_mass = average_vectors(&boundary_points).expect("Empty boundary?");
 
     let avg_dist_from_center = (center_of_mass - center).norm();

--- a/tests/exploration.rs
+++ b/tests/exploration.rs
@@ -2,11 +2,10 @@ use std::time::{Duration, Instant};
 
 use nalgebra::{vector, SVector};
 use sembas::{
-    adherer_core::SamplingError,
     adherers::const_adherer::ConstantAdhererFactory,
     explorer_core::Explorer,
     explorers::MeshExplorer,
-    structs::{Classifier, Domain, Halfspace, WithinMode},
+    structs::{Classifier, Domain, Halfspace, SamplingError, WithinMode},
 };
 
 const D: usize = 10;
@@ -23,10 +22,7 @@ struct Sphere<const N: usize> {
 }
 
 impl<const N: usize> Classifier<N> for Sphere<N> {
-    fn classify(
-        &mut self,
-        p: SVector<f64, N>,
-    ) -> Result<bool, sembas::adherer_core::SamplingError<N>> {
+    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
         if !self.domain.contains(&p) {
             return Err(SamplingError::OutOfBounds);
         }

--- a/tests/exploration.rs
+++ b/tests/exploration.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use nalgebra::{vector, SVector};
+use nalgebra::SVector;
 use sembas::{
     adherers::const_adherer::ConstantAdhererFactory,
     explorer_core::Explorer,
@@ -22,8 +22,8 @@ struct Sphere<const N: usize> {
 }
 
 impl<const N: usize> Classifier<N> for Sphere<N> {
-    fn classify(&mut self, p: SVector<f64, N>) -> Result<bool, SamplingError<N>> {
-        if !self.domain.contains(&p) {
+    fn classify(&mut self, p: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+        if !self.domain.contains(p) {
             return Err(SamplingError::OutOfBounds);
         }
 


### PR DESCRIPTION
This update further distinguishes between samples that are WithinMode and OutOfMode (previously referred to as Target and NonTarget) allowing functions to require and clarify what samples they are expecting. This also improves BoundaryPairs to explicitly require a in and out of mode sample.

Additionally, the samples support basic arithmetic operations with vectors and themselves, and conversions to SVectors.