### PR TITLE
Hotfix v0.2.1 hanging explorer

### DIFF
--- a/src/explorers/mesh_explorer.rs
+++ b/src/explorers/mesh_explorer.rs
@@ -159,11 +159,12 @@ impl<const N: usize> Explorer<N> for MeshExplorer<N> {
         }
 
         let node = if let Some(ref mut adh) = self.adherer {
-            let sample = adh.sample_next(classifier).inspect_err(|_| {})?;
+            let next = adh.sample_next(classifier);
+            let sample = match next {
+                Ok(result) => *result,
+                Err(e) => return Err(e),
+            };
 
-            // Clone needed, lifespan of sample attached to adherer. Adherer will be
-            // dropped when boundary found.
-            let sample = *sample;
             let state = adh.get_state();
 
             if let AdhererState::FoundBoundary(hs) = state {

--- a/tests/exploration.rs
+++ b/tests/exploration.rs
@@ -134,3 +134,78 @@ fn fully_explores_sphere() {
     // );
     // println!("{measured_points_per_area} - {ideal_points_per_area} = {}", measured_points_per_area - ideal_points_per_area);
 }
+
+#[test]
+fn oob_err_prunes_exploration_branch() {
+    struct TestClassifier<const N: usize> {}
+    impl<const N: usize> Classifier<N> for TestClassifier<N> {
+        fn classify(&mut self, _: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+            Err(SamplingError::OutOfBounds)
+        }
+    }
+    let mut classifier: Box<dyn Classifier<10>> = Box::new(TestClassifier {});
+
+    let b = WithinMode(SVector::from_fn(|_, _| 0.5));
+    let mut n = SVector::zeros();
+    n[0] = 1.0;
+    let root = Halfspace { b, n };
+    let adherer_f = ConstantAdhererFactory::new(ADH_DELTA_ANGLE, Some(ADH_MAX_ANGLE));
+
+    let mut expl = MeshExplorer::new(
+        JUMP_DISTANCE,
+        root,
+        JUMP_DISTANCE * 0.85,
+        Box::new(adherer_f),
+    );
+
+    let mut is_exploring = false;
+    let start = Instant::now();
+    while is_exploring {
+        if let Ok(p) = expl.step(&mut classifier) {
+            match p {
+                Some(_) => panic!("Unexpected point sampled?"),
+                None => is_exploring = false,
+            }
+        }
+
+        if start.elapsed() > Duration::from_secs(5) {
+            panic!("Explorer hung due to out of bounds exceptions!")
+        }
+    }
+}
+
+#[test]
+fn ble_err_prunes_exploration_branch() {
+    struct TestClassifier<const N: usize> {}
+    impl<const N: usize> Classifier<N> for TestClassifier<N> {
+        fn classify(&mut self, _: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
+            Ok(true)
+        }
+    }
+    let mut classifier: Box<dyn Classifier<10>> = Box::new(TestClassifier {});
+
+    let b = WithinMode(SVector::from_fn(|_, _| 0.5));
+    let mut n = SVector::zeros();
+    n[0] = 1.0;
+    let root = Halfspace { b, n };
+    let adherer_f = ConstantAdhererFactory::new(ADH_DELTA_ANGLE, Some(ADH_MAX_ANGLE));
+
+    let mut expl = MeshExplorer::new(
+        JUMP_DISTANCE,
+        root,
+        JUMP_DISTANCE * 0.85,
+        Box::new(adherer_f),
+    );
+
+    let mut is_exploring = false;
+    let start = Instant::now();
+    while is_exploring {
+        if let Ok(None) = expl.step(&mut classifier) {
+            is_exploring = false
+        }
+
+        if start.elapsed() > Duration::from_secs(5) {
+            panic!("Explorer hung due to boundary lost errors!")
+        }
+    }
+}

--- a/tests/exploration.rs
+++ b/tests/exploration.rs
@@ -137,13 +137,20 @@ fn fully_explores_sphere() {
 
 #[test]
 fn oob_err_prunes_exploration_branch() {
-    struct TestClassifier<const N: usize> {}
+    struct TestClassifier<const N: usize> {
+        i: usize,
+    }
     impl<const N: usize> Classifier<N> for TestClassifier<N> {
         fn classify(&mut self, _: &SVector<f64, N>) -> Result<bool, SamplingError<N>> {
-            Err(SamplingError::OutOfBounds)
+            if self.i > 2 {
+                Err(SamplingError::OutOfBounds)
+            } else {
+                self.i += 1;
+                Ok(true)
+            }
         }
     }
-    let mut classifier: Box<dyn Classifier<10>> = Box::new(TestClassifier {});
+    let mut classifier: Box<dyn Classifier<10>> = Box::new(TestClassifier { i: 0 });
 
     let b = WithinMode(SVector::from_fn(|_, _| 0.5));
     let mut n = SVector::zeros();
@@ -158,18 +165,15 @@ fn oob_err_prunes_exploration_branch() {
         Box::new(adherer_f),
     );
 
-    let mut is_exploring = false;
+    let mut is_exploring = true;
     let start = Instant::now();
     while is_exploring {
-        if let Ok(p) = expl.step(&mut classifier) {
-            match p {
-                Some(_) => panic!("Unexpected point sampled?"),
-                None => is_exploring = false,
-            }
+        if let Ok(None) = expl.step(&mut classifier) {
+            is_exploring = false;
         }
 
         if start.elapsed() > Duration::from_secs(5) {
-            panic!("Explorer hung due to out of bounds exceptions!")
+            panic!("Explorer hung due to out of bounds exceptions!");
         }
     }
 }
@@ -197,7 +201,7 @@ fn ble_err_prunes_exploration_branch() {
         Box::new(adherer_f),
     );
 
-    let mut is_exploring = false;
+    let mut is_exploring = true;
     let start = Instant::now();
     while is_exploring {
         if let Ok(None) = expl.step(&mut classifier) {


### PR DESCRIPTION
Fixes the problem where the MeshExplorer hangs when a boundary lost or out of bounds error occurs. This was due to the self.adherer not being reset after an error, resulting in the path not being pruned, and the path being infinitely re-attempted by the explorer despite being a dead-end.