### PR TITLE
Feature v0.3.0 backpropagation

### DIFF
--- a/src/structs/boundary.rs
+++ b/src/structs/boundary.rs
@@ -30,3 +30,11 @@ impl<const N: usize> BoundaryPair<N> {
         &self.x
     }
 }
+
+pub mod backprop {
+    use petgraph::graph::NodeIndex;
+
+    pub trait Backpropegation<const N: usize> {
+        fn backprop(&mut self, id: NodeIndex, margin: f64);
+    }
+}


### PR DESCRIPTION
Added Backpropagation trait and implemented backprop method for MeshExplorer. Improves orthonormal surface vector (OSV) error. For 10-dimensional sphere, reduced OSV error from 4% to 3%. OSV error is measured as the percent difference in the angle between the true surface direction and the approximated surface vector. For more sophisticated surfaces, this may improve, resulting in better sampling efficiency as well.