### PR TITLE
Feature v0.3.0 binary search adherer

### DIFF
--- a/src/adherers/bs_adherer.rs
+++ b/src/adherers/bs_adherer.rs
@@ -1,0 +1,134 @@
+use crate::{
+    adherer_core::{Adherer, AdhererFactory, AdhererState},
+    structs::{Classifier, Halfspace, OutOfMode, Sample, SamplingError, Span, WithinMode},
+};
+use nalgebra::{Const, OMatrix, SVector};
+use std::f64::consts::PI;
+
+/// Pivots around a known boundary halfspace by taking fixed-angle rotations until
+/// the boundary is crossed.
+pub struct BinarySearchAdherer<const N: usize> {
+    pivot: Halfspace<N>,
+    v: SVector<f64, N>,
+    samples: Vec<Sample<N>>,
+    n_iter: u32,
+    angle: f64,
+    prev_cls: Option<bool>,
+    t: Option<WithinMode<N>>,
+    x: Option<OutOfMode<N>>,
+    rot_factory: Box<dyn Fn(f64) -> OMatrix<f64, Const<N>, Const<N>>>,
+    pub state: AdhererState<N>,
+}
+
+/// Builds a ConstantAdherer instance.
+pub struct BinarySearchAdhererFactory<const N: usize> {
+    init_angle: f64,
+    n_iter: u32,
+}
+
+impl<const N: usize> BinarySearchAdherer<N> {
+    pub fn new(pivot: Halfspace<N>, v: SVector<f64, N>, init_angle: f64, n_iter: u32) -> Self {
+        let rot_factory = Span::new(pivot.n, v).get_rotater();
+
+        BinarySearchAdherer {
+            pivot,
+            v,
+            samples: vec![],
+            n_iter,
+            angle: init_angle,
+            prev_cls: None,
+            t: None,
+            x: None,
+            rot_factory: Box::new(rot_factory),
+            state: AdhererState::Searching,
+        }
+    }
+
+    fn take_initial_sample(
+        &mut self,
+        classifier: &mut Box<dyn Classifier<N>>,
+    ) -> Result<Sample<N>, SamplingError<N>> {
+        let cur = self.pivot.b + self.v;
+        let cls = classifier.classify(&cur)?;
+        self.prev_cls = Some(cls);
+
+        Ok(Sample::from_class(cur, cls))
+    }
+
+    fn take_sample(
+        &mut self,
+        prev_cls: bool,
+        classifier: &mut Box<dyn Classifier<N>>,
+    ) -> Result<Sample<N>, SamplingError<N>> {
+        let cof = if prev_cls { 1.0 } else { -1.0 };
+        let rot = (self.rot_factory)(cof * self.angle);
+        self.v = rot * self.v;
+
+        let cur = self.pivot.b + self.v;
+        let cls = classifier.classify(&cur)?;
+
+        self.angle /= 2.0;
+        self.n_iter -= 1;
+
+        if cls {
+            self.t = Some(cur.into());
+        } else {
+            self.x = Some(cur.into());
+        }
+
+        Ok(Sample::from_class(cur, cls))
+    }
+}
+
+impl<const N: usize> Adherer<N> for BinarySearchAdherer<N> {
+    fn get_state(&self) -> AdhererState<N> {
+        self.state
+    }
+
+    fn sample_next(
+        &mut self,
+        classifier: &mut Box<dyn Classifier<N>>,
+    ) -> Result<&Sample<N>, SamplingError<N>> {
+        let cur = if let Some(prev_cls) = self.prev_cls {
+            self.take_sample(prev_cls, classifier)?
+        } else {
+            self.take_initial_sample(classifier)?
+        };
+
+        if self.n_iter == 0 {
+            if let (Some(t), Some(_)) = (self.t, self.x) {
+                let rot90 = (self.rot_factory)(PI / 2.0);
+                let b = t;
+                let s = b - self.pivot.b;
+                let n = (rot90 * s).normalize();
+                self.state = AdhererState::FoundBoundary(Halfspace { b, n })
+            } else {
+                return Err(SamplingError::BoundaryLost);
+            }
+        }
+
+        self.samples.push(cur);
+
+        Ok(self
+            .samples
+            .last()
+            .expect("Invalid state, cur was not added to samples?"))
+    }
+}
+
+impl<const N: usize> BinarySearchAdhererFactory<N> {
+    pub fn new(init_angle: f64, n_iter: u32) -> Self {
+        BinarySearchAdhererFactory { init_angle, n_iter }
+    }
+}
+
+impl<const N: usize> AdhererFactory<N> for BinarySearchAdhererFactory<N> {
+    fn adhere_from(&self, hs: Halfspace<N>, v: SVector<f64, N>) -> Box<dyn Adherer<N>> {
+        Box::new(BinarySearchAdherer::new(
+            hs,
+            v,
+            self.init_angle,
+            self.n_iter,
+        ))
+    }
+}

--- a/src/adherers/bs_adherer.rs
+++ b/src/adherers/bs_adherer.rs
@@ -52,6 +52,14 @@ impl<const N: usize> BinarySearchAdherer<N> {
         let cls = classifier.classify(&cur)?;
         self.prev_cls = Some(cls);
 
+        if cls {
+            self.t = Some(cur.into());
+        } else {
+            self.x = Some(cur.into());
+        }
+
+        self.n_iter -= 1;
+
         Ok(Sample::from_class(cur, cls))
     }
 
@@ -75,6 +83,8 @@ impl<const N: usize> BinarySearchAdherer<N> {
         } else {
             self.x = Some(cur.into());
         }
+
+        self.prev_cls = Some(cls);
 
         Ok(Sample::from_class(cur, cls))
     }

--- a/src/adherers/bs_adherer.rs
+++ b/src/adherers/bs_adherer.rs
@@ -68,21 +68,21 @@ impl<const N: usize> BinarySearchAdherer<N> {
         prev_cls: bool,
         classifier: &mut Box<dyn Classifier<N>>,
     ) -> Result<Sample<N>, SamplingError<N>> {
-        let cof = if prev_cls { 1.0 } else { -1.0 };
-        let rot = (self.rot_factory)(cof * self.angle);
+        let ccw = if prev_cls { 1.0 } else { -1.0 };
+        let rot = (self.rot_factory)(ccw * self.angle);
         self.v = rot * self.v;
 
         let cur = self.pivot.b + self.v;
         let cls = classifier.classify(&cur)?;
-
-        self.angle /= 2.0;
-        self.n_iter -= 1;
 
         if cls {
             self.t = Some(cur.into());
         } else {
             self.x = Some(cur.into());
         }
+
+        self.angle /= 2.0;
+        self.n_iter -= 1;
 
         self.prev_cls = Some(cls);
 

--- a/src/adherers/mod.rs
+++ b/src/adherers/mod.rs
@@ -1,3 +1,4 @@
+pub mod bs_adherer;
 pub mod const_adherer;
 
 pub use const_adherer::*;

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -24,6 +24,18 @@ impl<T> Queue<T> for Vec<T> {
     }
 }
 
+impl<const N: usize> From<SVector<f64, N>> for WithinMode<N> {
+    fn from(value: SVector<f64, N>) -> Self {
+        Self(value)
+    }
+}
+
+impl<const N: usize> From<SVector<f64, N>> for OutOfMode<N> {
+    fn from(value: SVector<f64, N>) -> Self {
+        Self(value)
+    }
+}
+
 impl<const N: usize> From<Sample<N>> for SVector<f64, N> {
     fn from(value: Sample<N>) -> Self {
         value.into_inner()

--- a/src/structs/boundary.rs
+++ b/src/structs/boundary.rs
@@ -1,6 +1,6 @@
 use nalgebra::SVector;
 
-use super::{OutOfMode, WithinMode};
+use super::{OutOfMode, Sample, WithinMode};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BoundaryPair<const N: usize> {
@@ -19,7 +19,18 @@ pub struct Halfspace<const N: usize> {
 
 impl<const N: usize> BoundaryPair<N> {
     pub fn new(t: WithinMode<N>, x: OutOfMode<N>) -> Self {
-        BoundaryPair { t, x }
+        Self { t, x }
+    }
+
+    pub fn from_samples(s1: Sample<N>, s2: Sample<N>) -> Option<BoundaryPair<N>> {
+        if let (Sample::WithinMode(t), Sample::OutOfMode(x))
+        | (Sample::OutOfMode(x), Sample::WithinMode(t)) = (s1, s2)
+        {
+            // unreadable mess omg keel over and die past me
+            Some(BoundaryPair { t, x })
+        } else {
+            None
+        }
     }
 
     pub fn t(&self) -> &WithinMode<N> {


### PR DESCRIPTION
Adds the Binary Search Adherer (formally referred to as the Exponential Adherer), which rotates by an initial angle, then rotating by exponentially smaller angles to converge upon the boundary until a desired number of samples is reached.

Maximum error from boundary: $d \cdot \sin \left ( \frac{\theta_0}{2^{N-1}} \right)$, where $d$ is the jump distance, $\theta_0$ is the initial angle, and $N$ is the number of samples

