### PR TITLE
Feature v0.4.0 perf approx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,9 +378,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/boundary_tools/mod.rs
+++ b/src/boundary_tools/mod.rs
@@ -59,28 +59,6 @@ pub fn falls_on_boundary<const N: usize>(
     }
 }
 
-pub fn approx_prediction<const N: usize>(
-    p: SVector<f64, N>,
-    boundary: &Boundary<N>,
-    btree: &BoundaryRTree<N>,
-    k: u32,
-) -> Sample<N> {
-    let mut cls = true;
-    for (_, neighbor) in (0..k).zip(btree.nearest_neighbor_iter(&p.into())) {
-        let hs = boundary.get(neighbor.data).expect(
-            "Invalid neighbor index used on @boundary. Often a result of @boundary being out of sync or entirely different from @btree."
-        );
-
-        let s = (p - *hs.b).normalize();
-        if s.dot(&hs.n) > 0.0 {
-            cls = false;
-            break;
-        }
-    }
-
-    Sample::from_class(p, cls)
-}
-
 #[cfg(test)]
 mod falls_on_boundary_tests {
     use nalgebra::vector;


### PR DESCRIPTION
Adds approx_prediction for using the boundary to take samples of the performance mode without executing the FUT. These are estimations, meaning it's not guaranteed to be perfectly accurate.

These estimations use K-nearest neighbor to determine which halfspace(s) to compare the point against. If all halfspaces agree that the point falls within the envelope, then it's classified as WithinMode. 

These predictions may be improved using other Point-in-Shape algorithms, however since the boundary is a non-convex polytope, this becomes a complex issue for future work and research. Relevant keywords are: `convex decomposition, point-in-shape checking, H-representation, Quick Hull algorithm`.