### PR TITLE
Hotfix v0.4.0 binary surface search off by one error

### DIFF
--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -107,13 +107,13 @@ mod test_surfacer {
         let d = 0.05;
 
         // a little perturbed from the center
-        let mut t = SVector::from_fn(|_, _| 0.5);
+        let mut t: SVector<f64, D> = SVector::from_fn(|_, _| 0.5);
         t[D - 1] += 0.15;
         let t = WithinMode(t);
-        let mut x = SVector::from_fn(|_, _| 0.15);
+        let mut x: SVector<f64, D> = SVector::from_fn(|_, _| 0.15);
         x[0] += 0.3;
         let x = OutOfMode(x);
-        let max_samples = (DIAMETER / d).log2().ceil() as u32;
+        let max_samples = ((t - x).norm() / d).log2().ceil() as u32;
 
         let hs = binary_surface_search(d, &BoundaryPair::new(t, x), max_samples, &mut sphere)
             .expect("Failed to find boundary within the maximum number of samples ({max_samples})");

--- a/src/search/surfacing.rs
+++ b/src/search/surfacing.rs
@@ -19,25 +19,21 @@ pub fn binary_surface_search<const N: usize, C: Classifier<N>>(
 ) -> Result<Halfspace<N>> {
     let mut p_t = b_pair.t().0;
     let mut p_x = b_pair.x().0;
-    let mut s = (p_x - p_t) / 2.0;
+    let mut s = p_x - p_t;
     let mut i = 0;
 
     while s.norm() > max_err && i < max_samples {
+        s = (p_x - p_t) / 2.0;
+        i += 1;
+
         match classifier.classify(p_t + s)? {
             Sample::WithinMode(_) => p_t += s,
             Sample::OutOfMode(_) => p_x -= s,
         }
-        // if classifier.classify(&(p_t + s))? {
-        //     p_t += s;
-        // } else {
-        //     p_x -= s;
-        // }
-
-        s = (p_x - p_t) / 2.0;
-        i += 1
     }
 
     if i >= max_samples && s.norm() > max_err {
+        println!("Norm: {}", s.norm());
         return Err(SamplingError::MaxSamplesExceeded);
     }
 


### PR DESCRIPTION
The error had to do with not sampling enough times to converge upon the boundary within the specified `max_err` distance. This was due to an off-by-one error when dividing the search space in half, not classifying the final sample; effectively, returning the second to last sample.